### PR TITLE
Fix swim donut labels on mobile

### DIFF
--- a/frontend/src/pages/SwimTracking.jsx
+++ b/frontend/src/pages/SwimTracking.jsx
@@ -671,8 +671,8 @@ export default function SwimTracking() {
                       const percent = getStrokePercent(item?.payload?.yards || 0);
                       return [`${formatSwimDistance(value, unitSystem)} ${distanceLabels.summaryDistance} (${percent})`, name];
                     }}
-                    label={renderStrokeDonutLabel}
-                    labelLine
+                    label={isMobile ? false : renderStrokeDonutLabel}
+                    labelLine={!isMobile}
                   />
                 </div>
               </DashboardSection>


### PR DESCRIPTION
## Summary
- disable external donut callout labels on mobile for the Swim Tracking stroke composition chart
- keep desktop callouts intact so larger screens still show the inline stroke labels

## Testing
- npm run test:run -- SwimTracking.test.jsx charts.test.jsx