### PR TITLE
Refine swim distance trend tooltips

### DIFF
--- a/frontend/src/components/charts.jsx
+++ b/frontend/src/components/charts.jsx
@@ -31,6 +31,97 @@ const tooltipStyle = {
   color: '#0f172a',
 };
 
+function formatTooltipValue(item, formatter) {
+  if (typeof formatter !== 'function') {
+    return { value: item?.value, name: item?.name };
+  }
+
+  const formatted = formatter(item?.value, item?.name, item, item?.payload);
+  if (Array.isArray(formatted)) {
+    return {
+      value: formatted[0],
+      name: formatted[1] ?? item?.name,
+    };
+  }
+
+  return { value: formatted, name: item?.name };
+}
+
+export function shouldRenderColumnTooltip(payload, tooltipVisibilityPredicate = null) {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return false;
+  }
+
+  if (typeof tooltipVisibilityPredicate !== 'function') {
+    return true;
+  }
+
+  return Boolean(tooltipVisibilityPredicate(payload[0]?.payload, payload));
+}
+
+function DefaultColumnChartTooltipContent({ items, label, labelFormatter, valueFormatter }) {
+  return (
+    <div style={tooltipStyle}>
+      <p className="m-0 px-3 pt-2 text-sm font-semibold" style={{ color: '#0f172a' }}>
+        {typeof labelFormatter === 'function' ? labelFormatter(label) : label}
+      </p>
+      <div className="px-3 pb-2 pt-1">
+        {items.map((item) => {
+          const formatted = formatTooltipValue(item, valueFormatter);
+
+          return (
+            <p key={`${item.dataKey}-${item.name}`} className="m-0 text-sm" style={{ color: item.color || '#0f172a' }}>
+              {formatted.name}: {formatted.value}
+            </p>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function renderColumnTooltipContent({
+  active,
+  payload,
+  label,
+  valueFormatter,
+  labelFormatter,
+  tooltipVisibilityPredicate,
+  customTooltipContent,
+}) {
+  if (!active || !shouldRenderColumnTooltip(payload, tooltipVisibilityPredicate)) {
+    return null;
+  }
+
+  const items = payload.filter((item) => item && item.value !== null && item.value !== undefined);
+  if (items.length === 0) {
+    return null;
+  }
+
+  if (typeof customTooltipContent === 'function') {
+    return customTooltipContent({
+      items,
+      label,
+      valueFormatter,
+      labelFormatter,
+      payload,
+    });
+  }
+
+  return (
+    <DefaultColumnChartTooltipContent
+      items={items}
+      label={label}
+      labelFormatter={labelFormatter}
+      valueFormatter={valueFormatter}
+    />
+  );
+}
+
+function ColumnChartTooltipContent(props) {
+  return renderColumnTooltipContent(props);
+}
+
 function EmptyChartState({ emptyMessage }) {
   return (
     <ChartPanel className="flex h-[360px] items-center justify-center">
@@ -96,6 +187,8 @@ export function ColumnChartPanel({
   valueFormatter = (value) => value,
   labelFormatter = (label) => label,
   showLegend = true,
+  tooltipVisibilityPredicate = null,
+  customTooltipContent = null,
 }) {
   if (!Array.isArray(data) || data.length === 0) {
     return <EmptyChartState emptyMessage={emptyMessage} />;
@@ -113,7 +206,16 @@ export function ColumnChartPanel({
             tickFormatter={xTickFormatter}
           />
           <YAxis domain={yDomain} tick={{ fontSize: 12, fill: '#475569' }} tickFormatter={yTickFormatter} />
-          <Tooltip contentStyle={tooltipStyle} formatter={valueFormatter} labelFormatter={labelFormatter} />
+          <Tooltip
+            content={(
+              <ColumnChartTooltipContent
+                valueFormatter={valueFormatter}
+                labelFormatter={labelFormatter}
+                tooltipVisibilityPredicate={tooltipVisibilityPredicate}
+                customTooltipContent={customTooltipContent}
+              />
+            )}
+          />
           {showLegend && <Legend />}
           {bars.map((bar, idx) => (
             <Bar

--- a/frontend/src/components/charts.test.jsx
+++ b/frontend/src/components/charts.test.jsx
@@ -6,6 +6,8 @@ import {
   DonutChartPanel,
   LineChartPanel,
   PieChartPanel,
+  renderColumnTooltipContent,
+  shouldRenderColumnTooltip,
 } from './charts';
 
 describe('chart wrappers', () => {
@@ -36,5 +38,56 @@ describe('chart wrappers', () => {
       <DonutChartPanel data={[]} dataKey="yards" nameKey="stroke" emptyMessage="No donut data" />,
     );
     expect(donutHtml).toContain('No donut data');
+  });
+
+  test('render column tooltips by default when payload is present', () => {
+    const payload = [{ payload: { date: '2026-04-01', workout_count: 0, total_yards: 0 } }];
+
+    expect(shouldRenderColumnTooltip(payload)).toBe(true);
+  });
+
+  test('respect the optional column tooltip visibility predicate', () => {
+    const workoutPayload = [{ payload: { date: '2026-04-01', workout_count: 1, total_yards: 0 } }];
+    const emptyPayload = [{ payload: { date: '2026-04-02', workout_count: 0, total_yards: 0 } }];
+    const predicate = (entry) => entry.workout_count > 0;
+
+    expect(shouldRenderColumnTooltip(workoutPayload, predicate)).toBe(true);
+    expect(shouldRenderColumnTooltip(emptyPayload, predicate)).toBe(false);
+  });
+
+  test('render the default column tooltip content when no custom renderer is supplied', () => {
+    const html = renderToStaticMarkup(renderColumnTooltipContent({
+      active: true,
+      label: '2026-04-01',
+      valueFormatter: (value) => `${value} yards`,
+      labelFormatter: (label) => `Date: ${label}`,
+      payload: [{
+        dataKey: 'total_yards',
+        name: 'Distance',
+        value: 1200,
+        color: '#123456',
+        payload: { date: '2026-04-01', workout_count: 1, total_yards: 1200 },
+      }],
+    }));
+
+    expect(html).toContain('Date: 2026-04-01');
+    expect(html).toContain('Distance: 1200 yards');
+  });
+
+  test('allow a custom column tooltip renderer', () => {
+    const html = renderToStaticMarkup(renderColumnTooltipContent({
+      active: true,
+      label: '2026-04-01',
+      payload: [{
+        dataKey: 'total_yards',
+        name: 'Distance',
+        value: 1200,
+        color: '#123456',
+        payload: { date: '2026-04-01', workout_count: 1, total_yards: 1200 },
+      }],
+      customTooltipContent: ({ label, items }) => <section>{label}:{items[0].value}</section>,
+    }));
+
+    expect(html).toContain('2026-04-01:1200');
   });
 });

--- a/frontend/src/pages/SwimTracking.jsx
+++ b/frontend/src/pages/SwimTracking.jsx
@@ -115,6 +115,67 @@ export function formatSwimLongDistance(value, unitSystem = SWIM_UNIT_SYSTEMS.IMP
   return formatDecimal(converted, maximumFractionDigits);
 }
 
+export function shouldShowSwimDistanceTrendTooltip(entry) {
+  return Number(entry?.workout_count ?? 0) > 0;
+}
+
+export function shouldUseSwimDistanceTrendCardTooltip(isMobile) {
+  return !isMobile;
+}
+
+export function SwimDistanceTrendTooltipCard({ entry, label, unitSystem = SWIM_UNIT_SYSTEMS.IMPERIAL }) {
+  const workoutCount = Number(entry?.workout_count ?? 0);
+  const distanceLabels = getSwimDistanceUnitLabels(unitSystem);
+  const totalDurationMinutes = Number(entry?.total_duration_minutes ?? 0);
+
+  return (
+    <article
+      className="min-w-[220px] rounded-2xl border p-4 shadow-sm"
+      style={{
+        borderColor: 'var(--border-soft)',
+        backgroundColor: 'var(--bg-panel)',
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em]" style={{ color: 'var(--accent-600)' }}>
+            Workout Day
+          </p>
+          <p className="mt-1 text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {formatSwimChartDateTick(label, false)}
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em]" style={{ color: 'var(--text-muted)' }}>
+            Sessions
+          </p>
+          <p className="mt-1 text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {formatInteger(workoutCount)}
+          </p>
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-xl px-3 py-2" style={{ backgroundColor: 'var(--accent-50)' }}>
+          <p className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-muted)' }}>
+            Distance
+          </p>
+          <p className="mt-1 text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {formatSwimDistance(entry?.total_yards || 0, unitSystem)} {distanceLabels.shortDistance}
+          </p>
+        </div>
+        <div className="rounded-xl border px-3 py-2" style={{ backgroundColor: '#f8fbff', borderColor: 'var(--border-soft)' }}>
+          <p className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-muted)' }}>
+            Duration
+          </p>
+          <p className="mt-1 text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {formatSwimTime(totalDurationMinutes)}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
 export function renderStrokeDonutLabel({ cx, cy, midAngle, outerRadius, percent, name, payload }) {
   if (!percent || percent < 0.05) {
     return null;
@@ -283,6 +344,19 @@ export function paginateRecords(records = [], page = 1, pageSize = WORKOUTS_PAGE
   };
 }
 
+export function buildSwimDurationByDate(records = []) {
+  return records.reduce((totals, record) => {
+    const dateKey = record?.start_date_time ? String(record.start_date_time).slice(0, 10) : null;
+    if (!dateKey) {
+      return totals;
+    }
+
+    const duration = Number(record?.duration ?? 0);
+    totals.set(dateKey, (totals.get(dateKey) || 0) + (Number.isNaN(duration) ? 0 : duration));
+    return totals;
+  }, new Map());
+}
+
 export default function SwimTracking() {
   const [activeTab, setActiveTab] = useState('overview');
   const [selectedDays, setSelectedDays] = useState('365');
@@ -362,6 +436,7 @@ export default function SwimTracking() {
     if (!totalStrokeYards) return '0%';
     return `${Math.round((yards / totalStrokeYards) * 100)}%`;
   };
+  const durationByDate = buildSwimDurationByDate(records);
   const filledDailyData = (() => {
     if (!Array.isArray(dailyData) || dailyData.length === 0) return [];
 
@@ -383,6 +458,7 @@ export default function SwimTracking() {
         date: key,
         total_yards: existing?.total_yards ?? 0,
         workout_count: existing?.workout_count ?? 0,
+        total_duration_minutes: durationByDate.get(key) || 0,
       });
       cursor.setDate(cursor.getDate() + 1);
     }
@@ -399,6 +475,15 @@ export default function SwimTracking() {
   const dailyAxisInterval = isMobile
     ? Math.max(0, Math.floor(filledDailyData.length / 4))
     : Math.max(0, Math.floor(filledDailyData.length / 8));
+  const swimDistanceTrendTooltipContent = shouldUseSwimDistanceTrendCardTooltip(isMobile)
+    ? ({ items, label }) => (
+      <SwimDistanceTrendTooltipCard
+        entry={items[0]?.payload}
+        label={label}
+        unitSystem={unitSystem}
+      />
+    )
+    : null;
 
   return (
     <DashboardLayout
@@ -581,6 +666,8 @@ export default function SwimTracking() {
                   yTickFormatter={(value) => formatSwimDistance(value, unitSystem)}
                   valueFormatter={(value) => `${formatSwimDistance(value, unitSystem)} ${distanceLabels.mediumDistance}`}
                   labelFormatter={(date) => `Date: ${formatSwimChartDateTick(date, false)}`}
+                  tooltipVisibilityPredicate={shouldShowSwimDistanceTrendTooltip}
+                  customTooltipContent={swimDistanceTrendTooltipContent}
                 />
               </DashboardSection>
             )}

--- a/frontend/src/pages/SwimTracking.test.jsx
+++ b/frontend/src/pages/SwimTracking.test.jsx
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
+  buildSwimDurationByDate,
   WORKOUTS_PAGE_SIZE,
+  SwimDistanceTrendTooltipCard,
   SwimMobileWorkoutCard,
   buildRecentWorkoutColumns,
   convertMilesToKilometers,
@@ -13,6 +15,8 @@ import {
   formatSwimTime,
   getSwimDistanceUnitLabels,
   paginateRecords,
+  shouldShowSwimDistanceTrendTooltip,
+  shouldUseSwimDistanceTrendCardTooltip,
   SWIM_UNIT_SYSTEMS,
 } from './SwimTracking';
 
@@ -116,6 +120,68 @@ describe('paginateRecords', () => {
     expect(result.currentPage).toBe(1);
     expect(result.totalPages).toBe(1);
     expect(result.pageRows).toHaveLength(10);
+  });
+});
+
+describe('buildSwimDurationByDate', () => {
+  test('aggregates workout durations by workout date', () => {
+    const totals = buildSwimDurationByDate([
+      { start_date_time: '2026-03-28T06:00:00', duration: 45 },
+      { start_date_time: '2026-03-28T18:00:00', duration: 30 },
+      { start_date_time: '2026-03-29T09:15:00', duration: 60 },
+    ]);
+
+    expect(totals.get('2026-03-28')).toBe(75);
+    expect(totals.get('2026-03-29')).toBe(60);
+  });
+});
+
+describe('shouldShowSwimDistanceTrendTooltip', () => {
+  test('shows the tooltip for days with workouts even when distance is zero', () => {
+    expect(shouldShowSwimDistanceTrendTooltip({ workout_count: 1, total_yards: 0 })).toBe(true);
+  });
+
+  test('hides the tooltip for placeholder days without workouts', () => {
+    expect(shouldShowSwimDistanceTrendTooltip({ workout_count: 0, total_yards: 0 })).toBe(false);
+  });
+});
+
+describe('shouldUseSwimDistanceTrendCardTooltip', () => {
+  test('enables the card tooltip on desktop', () => {
+    expect(shouldUseSwimDistanceTrendCardTooltip(false)).toBe(true);
+  });
+
+  test('keeps the simple tooltip on mobile', () => {
+    expect(shouldUseSwimDistanceTrendCardTooltip(true)).toBe(false);
+  });
+});
+
+describe('SwimDistanceTrendTooltipCard', () => {
+  test('renders a desktop daily summary tooltip card in imperial units', () => {
+    const html = renderToStaticMarkup(
+      <SwimDistanceTrendTooltipCard
+        label="2026-03-28"
+        entry={{ workout_count: 2, total_yards: 2400, total_duration_minutes: 75 }}
+      />,
+    );
+
+    expect(html).toContain('Workout Day');
+    expect(html).toContain('2,400 yds');
+    expect(html).toContain('1h 15m');
+    expect(html).toContain('Mar');
+  });
+
+  test('renders a desktop daily summary tooltip card in metric units', () => {
+    const html = renderToStaticMarkup(
+      <SwimDistanceTrendTooltipCard
+        label="2026-03-28"
+        entry={{ workout_count: 1, total_yards: 1000, total_duration_minutes: 60 }}
+        unitSystem={SWIM_UNIT_SYSTEMS.METRIC}
+      />,
+    );
+
+    expect(html).toContain('914 m');
+    expect(html).toContain('1h 0m');
   });
 });
 


### PR DESCRIPTION
## Summary
- suppress Swim Distance Trend tooltips for placeholder days without workouts
- add a desktop card-style tooltip while keeping the simpler mobile tooltip
- replace duplicate workout count in the desktop tooltip card with total duration aggregated by day

## Testing
- npm run test:run -- src/pages/SwimTracking.test.jsx src/components/charts.test.jsx