### PR TITLE
Tame Swim Tracking tooltip animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pnpm-debug.log*
 Thumbs.db
 .idea/
 .vscode/
+.codex
 
 # Local SSH keys
 do-droplet

--- a/frontend/src/components/charts.jsx
+++ b/frontend/src/components/charts.jsx
@@ -189,6 +189,7 @@ export function ColumnChartPanel({
   showLegend = true,
   tooltipVisibilityPredicate = null,
   customTooltipContent = null,
+  tooltipAnimationActive = true,
 }) {
   if (!Array.isArray(data) || data.length === 0) {
     return <EmptyChartState emptyMessage={emptyMessage} />;
@@ -207,6 +208,7 @@ export function ColumnChartPanel({
           />
           <YAxis domain={yDomain} tick={{ fontSize: 12, fill: '#475569' }} tickFormatter={yTickFormatter} />
           <Tooltip
+            isAnimationActive={tooltipAnimationActive}
             content={(
               <ColumnChartTooltipContent
                 valueFormatter={valueFormatter}

--- a/frontend/src/components/charts.test.jsx
+++ b/frontend/src/components/charts.test.jsx
@@ -1,5 +1,36 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+
+vi.mock('recharts', () => {
+  const createWrapper = (tag) => {
+    const Wrapper = ({ children }) => React.createElement(tag, null, children);
+    Wrapper.displayName = tag;
+    return Wrapper;
+  };
+
+  return {
+    ResponsiveContainer: createWrapper('responsive-container'),
+    BarChart: createWrapper('bar-chart'),
+    Bar: createWrapper('bar'),
+    CartesianGrid: createWrapper('cartesian-grid'),
+    Cell: createWrapper('cell'),
+    Legend: createWrapper('legend'),
+    Line: createWrapper('line'),
+    LineChart: createWrapper('line-chart'),
+    LabelList: createWrapper('label-list'),
+    Pie: createWrapper('pie'),
+    PieChart: createWrapper('pie-chart'),
+    XAxis: createWrapper('x-axis'),
+    YAxis: createWrapper('y-axis'),
+    Tooltip: ({ children, content, isAnimationActive = true, ...props }) => React.createElement(
+      'tooltip',
+      { 'data-animation-active': String(isAnimationActive), ...props },
+      children || content,
+    ),
+  };
+});
+
 import {
   BarChartPanel,
   ColumnChartPanel,
@@ -72,6 +103,31 @@ describe('chart wrappers', () => {
 
     expect(html).toContain('Date: 2026-04-01');
     expect(html).toContain('Distance: 1200 yards');
+  });
+
+  test('keep tooltip animation enabled by default for column charts', () => {
+    const html = renderToStaticMarkup(
+      <ColumnChartPanel
+        data={[{ date: '2026-04-01', total_yards: 1200 }]}
+        xKey="date"
+        bars={[{ dataKey: 'total_yards', name: 'Distance' }]}
+      />,
+    );
+
+    expect(html).toContain('data-animation-active="true"');
+  });
+
+  test('allow column charts to disable tooltip animation explicitly', () => {
+    const html = renderToStaticMarkup(
+      <ColumnChartPanel
+        data={[{ date: '2026-04-01', total_yards: 1200 }]}
+        xKey="date"
+        bars={[{ dataKey: 'total_yards', name: 'Distance' }]}
+        tooltipAnimationActive={false}
+      />,
+    );
+
+    expect(html).toContain('data-animation-active="false"');
   });
 
   test('allow a custom column tooltip renderer', () => {

--- a/frontend/src/pages/SwimTracking.jsx
+++ b/frontend/src/pages/SwimTracking.jsx
@@ -123,6 +123,10 @@ export function shouldUseSwimDistanceTrendCardTooltip(isMobile) {
   return !isMobile;
 }
 
+export function shouldAnimateSwimDistanceTrendTooltip(isMobile) {
+  return Boolean(isMobile);
+}
+
 export function SwimDistanceTrendTooltipCard({ entry, label, unitSystem = SWIM_UNIT_SYSTEMS.IMPERIAL }) {
   const workoutCount = Number(entry?.workout_count ?? 0);
   const distanceLabels = getSwimDistanceUnitLabels(unitSystem);
@@ -668,6 +672,7 @@ export default function SwimTracking() {
                   labelFormatter={(date) => `Date: ${formatSwimChartDateTick(date, false)}`}
                   tooltipVisibilityPredicate={shouldShowSwimDistanceTrendTooltip}
                   customTooltipContent={swimDistanceTrendTooltipContent}
+                  tooltipAnimationActive={shouldAnimateSwimDistanceTrendTooltip(isMobile)}
                 />
               </DashboardSection>
             )}

--- a/frontend/src/pages/SwimTracking.test.jsx
+++ b/frontend/src/pages/SwimTracking.test.jsx
@@ -15,6 +15,7 @@ import {
   formatSwimTime,
   getSwimDistanceUnitLabels,
   paginateRecords,
+  shouldAnimateSwimDistanceTrendTooltip,
   shouldShowSwimDistanceTrendTooltip,
   shouldUseSwimDistanceTrendCardTooltip,
   SWIM_UNIT_SYSTEMS,
@@ -153,6 +154,16 @@ describe('shouldUseSwimDistanceTrendCardTooltip', () => {
 
   test('keeps the simple tooltip on mobile', () => {
     expect(shouldUseSwimDistanceTrendCardTooltip(true)).toBe(false);
+  });
+});
+
+describe('shouldAnimateSwimDistanceTrendTooltip', () => {
+  test('disables tooltip animation on desktop', () => {
+    expect(shouldAnimateSwimDistanceTrendTooltip(false)).toBe(false);
+  });
+
+  test('keeps tooltip animation enabled on mobile', () => {
+    expect(shouldAnimateSwimDistanceTrendTooltip(true)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an opt-in column chart tooltip animation toggle in the shared chart wrapper
- disable the desktop tooltip animation for the Swim Tracking distance trend chart
- cover the shared prop and Swim desktop/mobile behavior with focused frontend tests

## Testing
- npm test -- --run src/components/charts.test.jsx src/pages/SwimTracking.test.jsx