### PR TITLE
Add API docs navigation links

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,9 +1,13 @@
 """
 FastAPI application initialization and dashboard registration
 """
+import json
+from urllib.parse import urlsplit, urlunsplit
 from fastapi import FastAPI
+from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.responses import HTMLResponse, JSONResponse
 import logging
 from contextlib import asynccontextmanager
 from sqlalchemy import text
@@ -19,6 +23,7 @@ try:
         close_all_connections,
         configure_logging,
         get_cors_allowed_origins,
+        settings,
     )
 except ImportError:
     from backend.dashboards.registry import get_registry
@@ -26,6 +31,7 @@ except ImportError:
         close_all_connections,
         configure_logging,
         get_cors_allowed_origins,
+        settings,
     )
 
 configure_logging()
@@ -45,10 +51,11 @@ async def lifespan(_: FastAPI):
 
 app = FastAPI(
     title="Analytics & Reporting Hub API",
-    description="API definitions for small projects by John Thompson",
+    description="API definitions for the Analytics Hub",
     version="0.1.0",
     lifespan=lifespan,
     openapi_tags=registry.get_openapi_tags(),
+    docs_url=None,
 )
 
 # Configure CORS for frontend communication
@@ -60,6 +67,153 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def get_frontend_base_url(request: Request) -> str:
+    """Resolve the frontend origin for docs navigation links."""
+    configured = (getattr(settings, "frontend_base_url", None) or "").strip()
+    if configured:
+        return configured.rstrip("/")
+
+    url = urlsplit(str(request.base_url))
+    hostname = url.hostname or ""
+    port = url.port
+
+    if hostname in {"localhost", "127.0.0.1"} and port == 8000:
+        netloc = f"{hostname}:3000"
+        return urlunsplit((url.scheme, netloc, "", "", "")).rstrip("/")
+
+    return str(request.base_url).rstrip("/")
+
+
+def build_custom_docs_html(request: Request) -> str:
+    """Render Swagger UI with app-level navigation back to the frontend."""
+    swagger_html = get_swagger_ui_html(
+        openapi_url=app.openapi_url,
+        title=f"{app.title} - Swagger UI",
+    )
+    frontend_base_url = get_frontend_base_url(request)
+    dashboard_links = json.dumps(registry.get_docs_dashboard_links())
+    home_url = f"{frontend_base_url}/"
+
+    enhancement = f"""
+<style>
+  .codex-docs-header-actions {{
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin: 0.75rem 0 1.5rem;
+  }}
+  .codex-docs-link {{
+    color: #1f2937;
+    text-decoration: none;
+    font-weight: 600;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    border-radius: 999px;
+    padding: 0.45rem 0.85rem;
+    line-height: 1;
+    background: #fff;
+  }}
+  .codex-docs-link:hover {{
+    background: #f8fafc;
+  }}
+  .codex-docs-link--section {{
+    color: #0f172a;
+    border-color: rgba(15, 23, 42, 0.18);
+    margin-left: auto;
+    font-size: 0.875rem;
+  }}
+  .codex-docs-tag-row {{
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }}
+</style>
+<script>
+  window.addEventListener("load", function () {{
+    var frontendBaseUrl = {json.dumps(frontend_base_url)};
+    var homeUrl = {json.dumps(home_url)};
+    var dashboardLinks = {dashboard_links};
+    var titleToDashboard = new Map(
+      dashboardLinks.map(function (dashboard) {{
+        return [dashboard.title, dashboard];
+      }})
+    );
+
+    function ensureHeaderLink() {{
+      var info = document.querySelector(".swagger-ui .information-container .info");
+      if (!info || document.querySelector('[data-docs-home-link="true"]')) {{
+        return;
+      }}
+
+      var actions = info.querySelector(".codex-docs-header-actions");
+      if (!actions) {{
+        actions = document.createElement("div");
+        actions.className = "codex-docs-header-actions";
+
+        var openApiLink = info.querySelector("a[href$='openapi.json']");
+        if (openApiLink && openApiLink.parentNode === info) {{
+          openApiLink.insertAdjacentElement("afterend", actions);
+        }} else {{
+          info.appendChild(actions);
+        }}
+      }}
+
+      var link = document.createElement("a");
+      link.href = homeUrl;
+      link.textContent = "Back to Analytics Hub";
+      link.className = "codex-docs-link";
+      link.setAttribute("data-docs-home-link", "true");
+      actions.appendChild(link);
+    }}
+
+    function ensureDashboardSectionLinks() {{
+      document.querySelectorAll(".swagger-ui .opblock-tag-section").forEach(function (section) {{
+        var header = section.querySelector(".opblock-tag");
+        if (!header) {{
+          return;
+        }}
+
+        var titleNode = header.querySelector("a.nostyle span") || header.querySelector("span");
+        var title = titleNode ? titleNode.textContent.trim() : "";
+        var dashboard = titleToDashboard.get(title);
+        if (!dashboard || header.querySelector('[data-dashboard-link="true"]')) {{
+          return;
+        }}
+
+        header.classList.add("codex-docs-tag-row");
+
+        var link = document.createElement("a");
+        link.href = frontendBaseUrl + "/dashboard/" + dashboard.id;
+        link.textContent = "Open dashboard";
+        link.className = "codex-docs-link codex-docs-link--section";
+        link.setAttribute("data-dashboard-link", "true");
+        header.appendChild(link);
+      }});
+    }}
+
+    function enhanceDocs() {{
+      ensureHeaderLink();
+      ensureDashboardSectionLinks();
+    }}
+
+    enhanceDocs();
+
+    var observer = new MutationObserver(enhanceDocs);
+    observer.observe(document.body, {{ childList: true, subtree: true }});
+  }});
+</script>
+"""
+
+    return swagger_html.body.decode("utf-8").replace("</body>", f"{enhancement}</body>")
+
+
+@app.get("/docs", include_in_schema=False)
+async def overridden_swagger(request: Request):
+    """Serve Swagger UI with links back to the frontend experience."""
+    return HTMLResponse(build_custom_docs_html(request))
 
 
 @app.middleware("http")

--- a/backend/config.py
+++ b/backend/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     debug: bool = True
     log_level: str = "INFO"
     cors_allowed_origins: str = "*"
+    frontend_base_url: Optional[str] = None
     enable_mortgage_dashboard: bool = True
     enable_swim_dashboard: bool = True
     enable_rpi_dashboard: bool = True

--- a/backend/dashboards/registry.py
+++ b/backend/dashboards/registry.py
@@ -174,6 +174,16 @@ class DashboardRegistry:
             for dashboard in self.dashboards.values()
         ]
 
+    def get_docs_dashboard_links(self) -> List[Dict[str, str]]:
+        """Return dashboard link metadata for custom API docs navigation."""
+        return [
+            {
+                "id": dashboard.metadata.id,
+                "title": dashboard.metadata.title,
+            }
+            for dashboard in self.dashboards.values()
+        ]
+
 
 # Global registry instance
 _registry: DashboardRegistry = None

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -4,11 +4,12 @@ Integration-style smoke tests for key API endpoints.
 from contextlib import asynccontextmanager
 import pytest
 import httpx
+from starlette.requests import Request
 
 try:
-    from app import app, registry
+    from app import app, registry, get_frontend_base_url
 except ImportError:
-    from backend.app import app, registry
+    from backend.app import app, registry, get_frontend_base_url
 
 
 @asynccontextmanager
@@ -56,6 +57,34 @@ async def test_openapi_groups_general_and_dashboard_tags():
         assert all(tags != ("default",) for tags in dashboard_operation_tags)
         assert all(len(tags) == 1 for tags in dashboard_operation_tags)
         assert ("Mortgage Rates",) in dashboard_operation_tags
+
+
+@pytest.mark.asyncio
+async def test_custom_docs_page_includes_navigation_links():
+    async with get_client() as client:
+        response = await client.get("/docs")
+        assert response.status_code == 200
+        html = response.text
+
+        assert "Back to Analytics Hub" in html
+        assert '"id": "mortgage_rates"' in html
+        assert '"Open dashboard"' in html
+
+
+def test_get_frontend_base_url_maps_local_backend_port_to_vite_port():
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/docs",
+        "headers": [],
+        "server": ("localhost", 8000),
+        "scheme": "http",
+        "client": ("127.0.0.1", 12345),
+        "root_path": "",
+        "query_string": b"",
+    }
+
+    assert get_frontend_base_url(Request(scope)) == "http://localhost:3000"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -150,6 +150,16 @@ def test_get_openapi_tags_returns_general_and_dashboard_metadata():
     }
 
 
+def test_get_docs_dashboard_links_returns_dashboard_title_and_id():
+    """Test custom docs metadata exposes dashboard titles and ids."""
+    registry = DashboardRegistry()
+    registry.dashboards["test_dashboard"] = MockDashboard({})
+
+    links = registry.get_docs_dashboard_links()
+
+    assert links == [{"id": "test_dashboard", "title": "Test Dashboard"}]
+
+
 def test_disabled_dashboard_is_skipped(monkeypatch):
     """Test that disabled dashboards are not registered."""
     registry = DashboardRegistry()

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -28,6 +28,23 @@ const DASHBOARD_ACCENT_COLORS = {
 
 export const HOME_PAGE_TITLE = 'Analytics and Reporting Hub';
 
+export function getApiDocsUrl(locationLike = globalThis.location) {
+  const origin = locationLike?.origin;
+  const hostname = locationLike?.hostname;
+  const protocol = locationLike?.protocol || 'http:';
+  const port = locationLike?.port;
+
+  if (!origin && !hostname) {
+    return '/docs';
+  }
+
+  if ((hostname === 'localhost' || hostname === '127.0.0.1') && port === '3000') {
+    return `${protocol}//${hostname}:8000/docs`;
+  }
+
+  return `${origin || `${protocol}//${hostname}`}/docs`;
+}
+
 export function sortDashboardsByPreferredOrder(dashboards) {
   const orderMap = new Map(DASHBOARD_DISPLAY_ORDER.map((id, index) => [id, index]));
   return [...dashboards].sort((a, b) => {
@@ -63,10 +80,48 @@ export function DashboardCardContent({ dashboard, priority = false }) {
   );
 }
 
+export function HomeHeaderActions({ docsUrl }) {
+  return (
+    <div className="flex items-center gap-3">
+      <a
+        href={docsUrl}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Open API documentation"
+        className="dashboard-link focus-ring inline-flex items-center justify-center rounded-full border p-2"
+        style={{ borderColor: 'var(--border-soft)' }}
+      >
+        <span className="flex h-5 w-5 items-center justify-center text-[10px] font-bold leading-none" aria-hidden="true">
+          {'</>'}
+        </span>
+      </a>
+      <a
+        href="https://github.com/JohnMThompson/analytics-hub"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Open project GitHub repository"
+        className="dashboard-link focus-ring inline-flex items-center justify-center rounded-full border p-2"
+        style={{ borderColor: 'var(--border-soft)' }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-5 w-5"
+          aria-hidden="true"
+        >
+          <path d="M12 1.5A10.5 10.5 0 0 0 8.68 22c.52.09.7-.22.7-.5v-1.92c-2.86.62-3.47-1.2-3.47-1.2-.46-1.18-1.13-1.5-1.13-1.5-.92-.63.08-.62.08-.62 1.02.07 1.56 1.05 1.56 1.05.9 1.55 2.37 1.1 2.95.84.09-.66.35-1.1.64-1.35-2.28-.26-4.67-1.14-4.67-5.06 0-1.12.4-2.03 1.05-2.75-.1-.26-.46-1.32.1-2.74 0 0 .85-.27 2.8 1.05a9.6 9.6 0 0 1 5.1 0c1.95-1.32 2.8-1.05 2.8-1.05.56 1.42.2 2.48.1 2.74.66.72 1.05 1.63 1.05 2.75 0 3.93-2.4 4.8-4.69 5.05.36.31.68.93.68 1.88v2.79c0 .28.18.59.7.5A10.5 10.5 0 0 0 12 1.5Z" />
+        </svg>
+      </a>
+    </div>
+  );
+}
+
 export default function Home() {
   const [dashboards, setDashboards] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const docsUrl = getApiDocsUrl();
 
   useEffect(() => {
     fetchDashboards();
@@ -128,24 +183,7 @@ export default function Home() {
             <h1 className="dashboard-title">Analytics and Reporting Hub</h1>
             <p className="dashboard-subtitle">Choose a dashboard to view</p>
           </div>
-          <a
-            href="https://github.com/JohnMThompson/analytics-hub"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Open project GitHub repository"
-            className="dashboard-link focus-ring inline-flex items-center justify-center rounded-full border p-2"
-            style={{ borderColor: 'var(--border-soft)' }}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              className="h-5 w-5"
-              aria-hidden="true"
-            >
-              <path d="M12 1.5A10.5 10.5 0 0 0 8.68 22c.52.09.7-.22.7-.5v-1.92c-2.86.62-3.47-1.2-3.47-1.2-.46-1.18-1.13-1.5-1.13-1.5-.92-.63.08-.62.08-.62 1.02.07 1.56 1.05 1.56 1.05.9 1.55 2.37 1.1 2.95.84.09-.66.35-1.1.64-1.35-2.28-.26-4.67-1.14-4.67-5.06 0-1.12.4-2.03 1.05-2.75-.1-.26-.46-1.32.1-2.74 0 0 .85-.27 2.8 1.05a9.6 9.6 0 0 1 5.1 0c1.95-1.32 2.8-1.05 2.8-1.05.56 1.42.2 2.48.1 2.74.66.72 1.05 1.63 1.05 2.75 0 3.93-2.4 4.8-4.69 5.05.36.31.68.93.68 1.88v2.79c0 .28.18.59.7.5A10.5 10.5 0 0 0 12 1.5Z" />
-            </svg>
-          </a>
+          <HomeHeaderActions docsUrl={docsUrl} />
         </div>
       </header>
 

--- a/frontend/src/pages/Home.test.jsx
+++ b/frontend/src/pages/Home.test.jsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { DashboardCardContent, getDashboardAccentColor, HOME_PAGE_TITLE, sortDashboardsByPreferredOrder } from './Home';
+import { DashboardCardContent, getApiDocsUrl, getDashboardAccentColor, HomeHeaderActions, HOME_PAGE_TITLE, sortDashboardsByPreferredOrder } from './Home';
 import { setDocumentTitle } from '../utils/pageTitle';
 
 describe('sortDashboardsByPreferredOrder', () => {
@@ -91,5 +91,39 @@ describe('HOME_PAGE_TITLE', () => {
 
     expect(global.document.title).toBe('Analytics and Reporting Hub');
     delete global.document;
+  });
+});
+
+describe('getApiDocsUrl', () => {
+  test('maps local frontend dev traffic to the backend docs port', () => {
+    expect(
+      getApiDocsUrl({
+        origin: 'http://localhost:3000',
+        hostname: 'localhost',
+        protocol: 'http:',
+        port: '3000',
+      }),
+    ).toBe('http://localhost:8000/docs');
+  });
+
+  test('uses same-origin docs outside local dev', () => {
+    expect(
+      getApiDocsUrl({
+        origin: 'https://analytics.example.com',
+        hostname: 'analytics.example.com',
+        protocol: 'https:',
+        port: '',
+      }),
+    ).toBe('https://analytics.example.com/docs');
+  });
+});
+
+describe('Home header links', () => {
+  test('renders an API docs shortcut next to the GitHub shortcut', () => {
+    const html = renderToStaticMarkup(<HomeHeaderActions docsUrl="http://localhost:8000/docs" />);
+
+    expect(html).toContain('aria-label="Open API documentation"');
+    expect(html).toContain('href="http://localhost:8000/docs"');
+    expect(html).toContain('aria-label="Open project GitHub repository"');
   });
 });


### PR DESCRIPTION
## Summary
- add navigation back to the analytics hub from the API docs page
- add per-dashboard links from API docs sections to the live dashboards
- add an API docs shortcut to the landing page header and update the docs subtitle

## Testing
- pytest backend/tests/test_api_smoke.py backend/tests/test_registry.py
- npm test -- --run src/pages/Home.test.jsx